### PR TITLE
fix casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Output:
 
 #### • Performing JWE Decryption <a name="performing-jwe-decryption"></a>
 
-Call `encryption.decryptPayload` with a JSON response payload and a `JWEConfig` instance.
+Call `encryption.DecryptPayload` with a JSON response payload and a `JWEConfig` instance.
 
 Example using the configuration [above](#configuring-the-jwe-encryption):
 ```go
@@ -244,7 +244,7 @@ Example:
 encryptedPayload := "{" +
     "  \"encryptedData\": \"eyJraWQiOiI3NjFiMDAzYzFlYWRlM….Y+oPYKZEMTKyYcSIVEgtQw\"" +
     "}"
-payload = encryption.decryptPayload(encryptedPayload, config)
+payload = encryption.DecryptPayload(encryptedPayload, config)
 ```
 
 Output:


### PR DESCRIPTION
The code examples are showing the `DecryptPayload` function name with a lower case `d`, whereas it should be upper case 'D'

https://github.com/Mastercard/client-encryption-go/blob/master/encryption/encryption.go#L16