### PR TITLE
Enable setting encryption certificate fingerprint field

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ import github.com/mastercard/client-encryption-go
 ```
 
 ### Loading the Encryption Certificate <a name="loading-the-encryption-certificate"></a>
-A `Certificate` can be created by calling the `utils.LoadSigningKey` function:
+A `Certificate` can be created by calling the `utils.LoadEncryptionCertificate` function:
 ```go
 import "github.com/mastercard/client-encryption-go/utils"
 
@@ -302,7 +302,7 @@ import "github.com/mastercard/client-encryption-go/field_level_encryption"
 
 cb := field_level_encryption.NewFieldLevelEncryptionConfigBuilder()
 config, err := cb.WithDecryptionKey(decryptionKey).
-    WithCertificate(encryptionCertificate).
+    WithEncryptionCertificate(encryptionCertificate).
     WithEncryptionPath("$.path.to.foo", "$.path.to.encryptedFoo").
     WithDecryptionPath("$.path.to.encryptedFoo.encryptedData", "$.path.to.foo").
     WithEncryptedValueFieldName("encryptedData").

--- a/mastercard_encryption/mastercard_encryption.go
+++ b/mastercard_encryption/mastercard_encryption.go
@@ -47,6 +47,10 @@ func encryptPayloadPath(jsonPayload *gabs.Container, jsonPathIn string, jsonPath
 		encryptedObject.Set(params.EncryptedKeyValue, config.GetEncryptedKeyFieldName())
 	}
 
+	if !utils.IsNullOrEmpty(config.GetEncryptionCertificateFingerprintFieldName()) {
+		encryptedObject.Set(config.GetEncryptionCertificateFingerprint(), config.GetEncryptionCertificateFingerprintFieldName())
+	}
+
 	if !utils.IsNullOrEmpty(config.GetEncryptionKeyFingerprintFieldName()) {
 		encryptedObject.Set(config.GetEncryptionKeyFingerprint(), config.GetEncryptionKeyFingerprintFieldName())
 	}


### PR DESCRIPTION
Hello!

Currently, there is a method `WithEncryptionCertificateFingerprintFieldName`, but it takes no effect as the certificate fingerprint is not set to the encryption payload.

This PR fixes this.